### PR TITLE
Add POST /commutes

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ extern crate postgres;
 extern crate rustc_serialize;
 extern crate time;
 
-use nickel::{Nickel, HttpRouter};
+use nickel::{JsonBody, Nickel, HttpRouter};
 use rustc_serialize::json::ToJson;
 use postgres::{Connection, SslMode};
 use models::Commute;
@@ -43,6 +43,17 @@ fn main() {
         let commute = Commute::from_record(&row);
 
         commute.to_json()
+    });
+
+    router.post("/commutes", middleware! { |request|
+        match request.json_as::<Commute>().as_mut() {
+            Ok(commute) => {
+                // TODO: save to database
+                commute.id = Some(42);
+                commute.to_json()
+            },
+            Err(e) => format!("{{ message: '{:?}' }}", e).to_json(),
+        }
     });
 
     server.utilize(router);

--- a/src/models/commute.rs
+++ b/src/models/commute.rs
@@ -1,15 +1,18 @@
 use postgres::rows::Row;
+use rustc_serialize::Decoder;
 use rustc_serialize::json::{Json, ToJson};
 use std::collections::BTreeMap;
-use time::{Timespec, at};
+use super::timestamp::Timestamp;
 
+#[derive(RustcDecodable)]
+#[derive(Debug)]
 pub struct Commute {
-    pub id: i32,
+    pub id: Option<i32>,
     pub user_id: i32,
-    pub departed_at: Option<Timespec>,
-    pub arrived_at: Option<Timespec>,
-    pub created_at: Option<Timespec>,
-    pub updated_at: Option<Timespec>,
+    pub departed_at: Timestamp,
+    pub arrived_at: Timestamp,
+    pub created_at: Timestamp,
+    pub updated_at: Timestamp,
 }
 
 impl Commute {
@@ -17,29 +20,26 @@ impl Commute {
         Commute {
             id: row.get("id"),
             user_id: row.get("user_id"),
-            departed_at: row.get("departed_at"),
-            arrived_at: row.get("arrived_at"),
-            created_at: row.get("created_at"),
-            updated_at: row.get("updated_at"),
+            departed_at: Timestamp::Some(row.get("departed_at")),
+            arrived_at: Timestamp::Some(row.get("arrived_at")),
+            created_at: Timestamp::Some(row.get("created_at")),
+            updated_at: Timestamp::Some(row.get("updated_at")),
         }
     }
 }
 
+// TODO: look at the serde crate as an alternative to rustc_serialize
 impl ToJson for Commute {
     fn to_json(&self) -> Json {
         let mut map = BTreeMap::new();
 
         map.insert("id".to_string(), self.id.to_json());
         map.insert("user_id".to_string(), self.user_id.to_json());
-        map.insert("departed_at".to_string(), timespec_to_json(self.departed_at.unwrap()));
-        map.insert("arrived_at".to_string(), timespec_to_json(self.arrived_at.unwrap()));
-        map.insert("created_at".to_string(), timespec_to_json(self.created_at.unwrap()));
-        map.insert("updated_at".to_string(), timespec_to_json(self.updated_at.unwrap()));
+        map.insert("departed_at".to_string(), self.departed_at.to_json());
+        map.insert("arrived_at".to_string(), self.arrived_at.to_json());
+        map.insert("created_at".to_string(), self.created_at.to_json());
+        map.insert("updated_at".to_string(), self.updated_at.to_json());
 
         Json::Object(map)
     }
-}
-
-fn timespec_to_json(timespec: Timespec) -> Json {
-    at(timespec).to_utc().rfc3339().to_string().to_json()
 }

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,3 +1,5 @@
 pub use self::commute::Commute;
+pub use self::timestamp::Timestamp;
 
 mod commute;
+mod timestamp;

--- a/src/models/timestamp.rs
+++ b/src/models/timestamp.rs
@@ -1,0 +1,27 @@
+use rustc_serialize::{Decoder, Decodable};
+use rustc_serialize::json::{ToJson, Json};
+use time::{Timespec, strptime, at};
+
+#[derive(Debug)]
+pub enum Timestamp {
+    Some(Timespec),
+    None,
+}
+
+impl Decodable for Timestamp {
+    fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, D::Error> {
+        decoder.read_str().
+            and_then(|s| strptime(&s, "%Y-%m-%dT%H:%M:%SZ").map_err(|_| decoder.error("ignored"))).
+            and_then(|t| Ok(Timestamp::Some(t.to_timespec()))).
+            or_else(|_| Ok(Timestamp::None))
+    }
+}
+
+impl ToJson for Timestamp {
+    fn to_json(&self) -> Json {
+        match self {
+            &Timestamp::Some(timespec) => at(timespec).to_utc().rfc3339().to_string().to_json(),
+            &Timestamp::None => Json::Null
+        }
+    }
+}


### PR DESCRIPTION
Adds POST endpoint to parse a JSON body as a Commute object. Does not
save the commute to the database yet.

I don't think this code is as good as it could be, but it's better than
I expected to have come up with in the short amount of time I've looked
at it. I have a feeling I don't need to implement ToJson for Commute and
can instead implement Encodable on Commute and Timestamp, but I wasn't
able to get it working. I think I'll revisit it.

The rustc_serialize docs [mention an alternative](http://doc.rust-lang.org/rustc-serialize/rustc_serialize/json/index.html#the-status-of-this-library) library, [Serde](https://crates.io/crates/serde),
which I want to check out as well.
